### PR TITLE
Update NVCC: 10.1.243 -> 11.0.221

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,32 @@ RUN apt-get update && \
     apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial-updates universe" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
+        ca-certificates gnupg \
         git astyle ninja-build make unzip iwyu libidn11 valgrind \
-        lsb-release wget software-properties-common lcov gpg-agent nvidia-cuda-toolkit \
+        lsb-release wget software-properties-common lcov gpg-agent \
         g++-4.8 g++-4.9 g++-5 g++-6 g++-7 g++-8 g++-9 g++-10 g++-11 g++ \
         clang-3.5 clang-3.6 clang-3.7 clang-3.8 clang-3.9 clang-4.0 clang-5.0 clang-6.0 clang-7 clang-8 clang-9 clang-10 clang-11 clang-12 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+############################
+# get a newer CUDA Toolkit #
+############################
+
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub && \
+    apt-key add 7fa2af80.pub && \
+    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /" \
+    | tee /etc/apt/sources.list.d/cuda.list && \
+    apt-get update && \
+    apt-get install -y             \
+      cuda-command-line-tools-11-0 \
+      cuda-compiler-11-0           \
+      cuda-minimal-build-11-0   && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s cuda-11.0 /usr/local/cuda
+
+ENV PATH=${PATH}:/usr/local/cuda/bin
 
 ####################
 # get latest CMake #

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker pull nlohmann/json-ci:latest
 
 The goal is to provide a fairly recent C++ build and analysis tool chain.
 
-Versions (as of 2021-11-21):
+Versions (as of 2021-12-29):
 
 - Clang 14.0.0-++20211221052852+55c71c9eac9b-1~exp1~20211221172954.95
 - GCC 12.0.0 20211219 (experimental)
@@ -56,7 +56,7 @@ Furthermore, some "historic" C++ compilers are available:
 - clang 11.0.0
 - clang 12.0.0
 - clang 13.0.1-++20211015123032+cf15ccdeb6d5-1~exp1~20211015003613.5
-- nvcc 10.1.243
+- nvcc 11.0.221
 
 
 ### Scripts


### PR DESCRIPTION
Try to skip the CUDA toolkit shipped with `ubuntu:latest` and go straight for a newer one, hoping that we can avoid having to work-around some compiler bugs.

- [x] run locally and see if that version of the CUDA toolkit already helps us, or if we need an even newer one

Related to https://github.com/nlohmann/json/issues/2676