### PR TITLE
[WIP] Split monolithic json-ci image into many images

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,0 +1,370 @@
+name: Publish Docker images
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build_and_publish-gcc-4.8:
+    name: Build and publish Docker image json-ci-gcc-4.8
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the GitHub Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image json-ci-gcc-4.8
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: json-ci-gcc-4.8
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_and_publish-gcc-4.9:
+    name: Build and publish Docker image json-ci-gcc-4.9
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the GitHub Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image json-ci-gcc-4.9
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: json-ci-gcc-4.9
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_and_publish-gcc-5:
+    name: Build and publish Docker image json-ci-gcc-5
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the GitHub Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image json-ci-gcc-5
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: json-ci-gcc-5
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_and_publish-gcc-6:
+    name: Build and publish Docker image json-ci-gcc-6
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the GitHub Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image json-ci-gcc-6
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: json-ci-gcc-6
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_and_publish-gcc-7:
+    name: Build and publish Docker image json-ci-gcc-7
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the GitHub Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image json-ci-gcc-7
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: json-ci-gcc-7
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_and_publish-gcc-8:
+    name: Build and publish Docker image json-ci-gcc-8
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the GitHub Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image json-ci-gcc-8
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: json-ci-gcc-8
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_and_publish-gcc-9:
+    name: Build and publish Docker image json-ci-gcc-9
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the GitHub Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image json-ci-gcc-9
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: json-ci-gcc-9
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_and_publish-gcc-10:
+    name: Build and publish Docker image json-ci-gcc-10
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the GitHub Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image json-ci-gcc-10
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: json-ci-gcc-10
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_and_publish-gcc-11:
+    name: Build and publish Docker image json-ci-gcc-11
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the GitHub Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image json-ci-gcc-11
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: json-ci-gcc-11
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_and_publish-gcc-12:
+    name: Build and publish Docker image json-ci-gcc-12
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the GitHub Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image json-ci-gcc-12
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: json-ci-gcc-12
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_and_publish-gcc-latest:
+    name: Build and publish Docker image json-ci-gcc-latest
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the GitHub Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image json-ci-gcc-latest
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          target: json-ci-gcc-latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -45,6 +45,6 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# venv
+/.venv-stamp
+/venv/

--- a/Dockerfile.gcc-10
+++ b/Dockerfile.gcc-10
@@ -1,0 +1,23 @@
+FROM ubuntu:jammy AS json-ci-base-jammy
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ focal main universe" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git gnupg gpg-agent lsb-release \
+        make ninja-build unzip wget xz-utils && \
+    CMAKE_VERSION=3.24.0 && \
+    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir && \
+    rm -v cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    rm -v /usr/local/bin/ccmake /usr/local/bin/cmake-gui /usr/local/bin/cpack && \
+    rm -rf /usr/local/doc/cmake /usr/local/man && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ && \
+    find /usr/lib/x86_64-linux-gnu -type f -iname '*.a' -exec rm -v \{\} \+
+FROM json-ci-base-jammy AS json-ci-gcc-10
+RUN apt-get install -y --no-install-recommends \
+        g++-10 \
+        g++-10-multilib

--- a/Dockerfile.gcc-11
+++ b/Dockerfile.gcc-11
@@ -1,0 +1,23 @@
+FROM ubuntu:jammy AS json-ci-base-jammy
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ focal main universe" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git gnupg gpg-agent lsb-release \
+        make ninja-build unzip wget xz-utils && \
+    CMAKE_VERSION=3.24.0 && \
+    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir && \
+    rm -v cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    rm -v /usr/local/bin/ccmake /usr/local/bin/cmake-gui /usr/local/bin/cpack && \
+    rm -rf /usr/local/doc/cmake /usr/local/man && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ && \
+    find /usr/lib/x86_64-linux-gnu -type f -iname '*.a' -exec rm -v \{\} \+
+FROM json-ci-base-jammy AS json-ci-gcc-11
+RUN apt-get install -y --no-install-recommends \
+        g++-11 \
+        g++-11-multilib

--- a/Dockerfile.gcc-12
+++ b/Dockerfile.gcc-12
@@ -1,0 +1,23 @@
+FROM ubuntu:jammy AS json-ci-base-jammy
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ focal main universe" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git gnupg gpg-agent lsb-release \
+        make ninja-build unzip wget xz-utils && \
+    CMAKE_VERSION=3.24.0 && \
+    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir && \
+    rm -v cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    rm -v /usr/local/bin/ccmake /usr/local/bin/cmake-gui /usr/local/bin/cpack && \
+    rm -rf /usr/local/doc/cmake /usr/local/man && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ && \
+    find /usr/lib/x86_64-linux-gnu -type f -iname '*.a' -exec rm -v \{\} \+
+FROM json-ci-base-jammy AS json-ci-gcc-12
+RUN apt-get install -y --no-install-recommends \
+        g++-12 \
+        g++-12-multilib

--- a/Dockerfile.gcc-4.8
+++ b/Dockerfile.gcc-4.8
@@ -1,0 +1,26 @@
+FROM ubuntu:focal AS json-ci-base-focal
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ bionic main universe" && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial main universe" && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial-updates main universe" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git gnupg gpg-agent lsb-release \
+        make ninja-build unzip wget xz-utils \
+        libidn11 && \
+    CMAKE_VERSION=3.24.0 && \
+    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir && \
+    rm -v cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    rm -v /usr/local/bin/ccmake /usr/local/bin/cmake-gui /usr/local/bin/cpack && \
+    rm -rf /usr/local/doc/cmake /usr/local/man && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ && \
+    find /usr/lib/x86_64-linux-gnu -type f -iname '*.a' -exec rm -v \{\} \+
+FROM json-ci-base-focal AS json-ci-gcc-4.8
+RUN apt-get install -y --no-install-recommends \
+        g++-4.8 \
+        g++-4.8-multilib

--- a/Dockerfile.gcc-4.9
+++ b/Dockerfile.gcc-4.9
@@ -1,0 +1,26 @@
+FROM ubuntu:focal AS json-ci-base-focal
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ bionic main universe" && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial main universe" && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial-updates main universe" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git gnupg gpg-agent lsb-release \
+        make ninja-build unzip wget xz-utils \
+        libidn11 && \
+    CMAKE_VERSION=3.24.0 && \
+    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir && \
+    rm -v cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    rm -v /usr/local/bin/ccmake /usr/local/bin/cmake-gui /usr/local/bin/cpack && \
+    rm -rf /usr/local/doc/cmake /usr/local/man && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ && \
+    find /usr/lib/x86_64-linux-gnu -type f -iname '*.a' -exec rm -v \{\} \+
+FROM json-ci-base-focal AS json-ci-gcc-4.9
+RUN apt-get install -y --no-install-recommends \
+        g++-4.9 \
+        g++-4.9-multilib

--- a/Dockerfile.gcc-5
+++ b/Dockerfile.gcc-5
@@ -1,0 +1,26 @@
+FROM ubuntu:focal AS json-ci-base-focal
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ bionic main universe" && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial main universe" && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial-updates main universe" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git gnupg gpg-agent lsb-release \
+        make ninja-build unzip wget xz-utils \
+        libidn11 && \
+    CMAKE_VERSION=3.24.0 && \
+    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir && \
+    rm -v cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    rm -v /usr/local/bin/ccmake /usr/local/bin/cmake-gui /usr/local/bin/cpack && \
+    rm -rf /usr/local/doc/cmake /usr/local/man && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ && \
+    find /usr/lib/x86_64-linux-gnu -type f -iname '*.a' -exec rm -v \{\} \+
+FROM json-ci-base-focal AS json-ci-gcc-5
+RUN apt-get install -y --no-install-recommends \
+        g++-5 \
+        g++-5-multilib

--- a/Dockerfile.gcc-6
+++ b/Dockerfile.gcc-6
@@ -1,0 +1,26 @@
+FROM ubuntu:focal AS json-ci-base-focal
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ bionic main universe" && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial main universe" && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial-updates main universe" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git gnupg gpg-agent lsb-release \
+        make ninja-build unzip wget xz-utils \
+        libidn11 && \
+    CMAKE_VERSION=3.24.0 && \
+    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir && \
+    rm -v cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    rm -v /usr/local/bin/ccmake /usr/local/bin/cmake-gui /usr/local/bin/cpack && \
+    rm -rf /usr/local/doc/cmake /usr/local/man && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ && \
+    find /usr/lib/x86_64-linux-gnu -type f -iname '*.a' -exec rm -v \{\} \+
+FROM json-ci-base-focal AS json-ci-gcc-6
+RUN apt-get install -y --no-install-recommends \
+        g++-6 \
+        g++-6-multilib

--- a/Dockerfile.gcc-7
+++ b/Dockerfile.gcc-7
@@ -1,0 +1,26 @@
+FROM ubuntu:focal AS json-ci-base-focal
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ bionic main universe" && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial main universe" && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial-updates main universe" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git gnupg gpg-agent lsb-release \
+        make ninja-build unzip wget xz-utils \
+        libidn11 && \
+    CMAKE_VERSION=3.24.0 && \
+    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir && \
+    rm -v cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    rm -v /usr/local/bin/ccmake /usr/local/bin/cmake-gui /usr/local/bin/cpack && \
+    rm -rf /usr/local/doc/cmake /usr/local/man && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ && \
+    find /usr/lib/x86_64-linux-gnu -type f -iname '*.a' -exec rm -v \{\} \+
+FROM json-ci-base-focal AS json-ci-gcc-7
+RUN apt-get install -y --no-install-recommends \
+        g++-7 \
+        g++-7-multilib

--- a/Dockerfile.gcc-8
+++ b/Dockerfile.gcc-8
@@ -1,0 +1,26 @@
+FROM ubuntu:focal AS json-ci-base-focal
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ bionic main universe" && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial main universe" && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial-updates main universe" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git gnupg gpg-agent lsb-release \
+        make ninja-build unzip wget xz-utils \
+        libidn11 && \
+    CMAKE_VERSION=3.24.0 && \
+    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir && \
+    rm -v cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    rm -v /usr/local/bin/ccmake /usr/local/bin/cmake-gui /usr/local/bin/cpack && \
+    rm -rf /usr/local/doc/cmake /usr/local/man && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ && \
+    find /usr/lib/x86_64-linux-gnu -type f -iname '*.a' -exec rm -v \{\} \+
+FROM json-ci-base-focal AS json-ci-gcc-8
+RUN apt-get install -y --no-install-recommends \
+        g++-8 \
+        g++-8-multilib

--- a/Dockerfile.gcc-9
+++ b/Dockerfile.gcc-9
@@ -1,0 +1,23 @@
+FROM ubuntu:jammy AS json-ci-base-jammy
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ focal main universe" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git gnupg gpg-agent lsb-release \
+        make ninja-build unzip wget xz-utils && \
+    CMAKE_VERSION=3.24.0 && \
+    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir && \
+    rm -v cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    rm -v /usr/local/bin/ccmake /usr/local/bin/cmake-gui /usr/local/bin/cpack && \
+    rm -rf /usr/local/doc/cmake /usr/local/man && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ && \
+    find /usr/lib/x86_64-linux-gnu -type f -iname '*.a' -exec rm -v \{\} \+
+FROM json-ci-base-jammy AS json-ci-gcc-9
+RUN apt-get install -y --no-install-recommends \
+        g++-9 \
+        g++-9-multilib

--- a/Dockerfile.gcc-latest
+++ b/Dockerfile.gcc-latest
@@ -1,0 +1,26 @@
+FROM ubuntu:jammy AS json-ci-base-jammy
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu/ focal main universe" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git gnupg gpg-agent lsb-release \
+        make ninja-build unzip wget xz-utils && \
+    CMAKE_VERSION=3.24.0 && \
+    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir && \
+    rm -v cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+    rm -v /usr/local/bin/ccmake /usr/local/bin/cmake-gui /usr/local/bin/cpack && \
+    rm -rf /usr/local/doc/cmake /usr/local/man && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ && \
+    find /usr/lib/x86_64-linux-gnu -type f -iname '*.a' -exec rm -v \{\} \+
+FROM json-ci-base-jammy AS json-ci-gcc-latest
+RUN wget http://kayari.org/gcc-latest/gcc-latest.deb && \
+    dpkg -i gcc-latest.deb && \
+    rm -rf gcc-latest.deb && \
+    ln -sv /opt/gcc-latest/bin/g++ /opt/gcc-latest/bin/g++-latest && \
+    ln -sv /opt/gcc-latest/bin/gcc /opt/gcc-latest/bin/gcc-latest
+ENV PATH=${PATH}:/opt/gcc-latest/bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+JSON_CI_VENV ?= venv
+JSON_CI_USE_VENV ?= true
+
+.ONESHELL:
+.SHELLFLAGS: -e
+
+ALL_DEPS = update
+ifeq ($(JSON_CI_USE_VENV),true)
+		ALL_DEPS = install_venv update
+endif
+
+.PHONY: all
+all: $(ALL_DEPS)
+
+# update all
+.PHONY: update
+update: update_docker update_workflows
+
+# update Dockerfiles
+.PHONY: update_docker
+update_docker:
+	@[ "x$(JSON_CI_USE_VENV)" == "xtrue" ] && . $(JSON_CI_VENV)/bin/activate
+	./generate_dockerfiles.py
+
+# update GitHub workflows
+.PHONY: update_workflows
+update_workflows:
+	@[ "x$(JSON_CI_USE_VENV)" == "xtrue" ] && . $(JSON_CI_VENV)/bin/activate
+	./generate_workflows.py
+
+# install a Python virtual environment
+.PHONY: install_venv
+install_venv: .venv-stamp
+	python3 -mvenv $(JSON_CI_VENV)
+	$(JSON_CI_VENV)/bin/pip install --upgrade pip
+	$(JSON_CI_VENV)/bin/pip install wheel
+	$(JSON_CI_VENV)/bin/pip install -r requirements.txt
+
+.venv-stamp: requirements.txt
+	@touch $@
+
+# uninstall the virtual environment
+uninstall_venv:
+	rm -fr $(JSON_CI_VENV) .venv-stamp

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,9 @@
+gcc-focal-images:
+  template: 'Dockerfile.gcc-focal.j2'
+  image: 'gcc'
+  versions: ['4.8', '4.9', '5', '6', '7', '8']
+
+gcc-jammy-images:
+  template: 'Dockerfile.gcc-jammy.j2'
+  image: 'gcc'
+  versions: ['9', '10', '11', '12', 'latest']

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import pathlib
+import re
+import sys
+import yaml
+
+from jinja2 import Environment, FileSystemLoader
+
+CONFIG_FILE = 'config.yml'
+RUN = 'RUN '
+INDENT = 4
+IMAGE_PATTERN = re.compile(r'(?P<base>\w+(-\w+)*)(-(?P<version>\d+(\.\d+(\.\d+)?)?))?')
+KEYWORD_PATTERN = re.compile(r'^(?P<keyword>[A-Z]+)\s+')
+
+def docker_fuse_run(text):
+    '''Merges consecutive RUN statements.'''
+
+    lines = [line for line in map(str.strip, text.split('\n')) if line and not line.startswith('#')]
+    out = []
+    first_run = True
+
+    for line in lines:
+        match = KEYWORD_PATTERN.match(line)
+        if match:
+            if match.group('keyword') == 'RUN':
+                if first_run:
+                    first_run = False
+                else:
+                    out[-1] += ' && \\'
+                    line = (' ' * len(RUN)) + line.removeprefix(RUN)
+            else:
+                first_run = True                
+        else:
+            line = (' ' * (len(RUN) + INDENT)) + line
+        
+        out.append(line)
+
+    return '\n'.join(out)
+
+def docker_multiline(text):
+    '''Add line continuations.'''
+
+    lines = [line for line in map(str.strip, text.split('\n')) if line and not line.startswith('#')]
+
+    for line in lines:
+        if not line.startswith(RUN):
+            line = (' ' * (len(RUN) + INDENT)) + line
+
+    return ' \\\n'.join(lines)
+
+if __name__ == '__main__':
+    project_dir = pathlib.Path(sys.path[0])
+    src_dir = project_dir / 'src/docker/'
+    template_dir = src_dir / 'templates/'
+
+    # load config
+    with open(project_dir / CONFIG_FILE, 'r') as f:
+        config = yaml.safe_load(f)
+
+    env = Environment(loader=FileSystemLoader(searchpath=[src_dir, template_dir]), autoescape=False, trim_blocks=True,
+                                              lstrip_blocks=True, keep_trailing_newline=True)
+    env.filters['docker.fuse_run'] = docker_fuse_run
+    env.filters['docker.multiline'] = docker_multiline
+
+    # for file in src_dir.glob('Dockerfile.*.j2'):
+    #     image = file.stem.removeprefix('Dockerfile.')
+    #     match = IMAGE_PATTERN.fullmatch(image)
+
+    #     context = {
+    #         'image': image,
+    #         'image_base': match.group('base'),
+    #         'image_version': match.group('version')
+    #     }
+
+    for key in config:
+        entry = config[key]
+        if not {'template', 'image', 'versions'} <= set(entry):
+            raise ValueError(f'Invalid config entry: {key}')
+        
+        image_base = entry['image']
+        for version in entry['versions']:
+            image = f'{image_base}-{version}'
+            context = {
+                'image': image,
+                'image_base': image_base,
+                'image_version': version
+            }
+
+            template = env.get_template(entry['template'])
+            dockerfile = docker_fuse_run(template.render(context))
+
+            print(dockerfile)
+
+            with open(project_dir / f'Dockerfile.{image}', 'w') as f:
+                f.write(dockerfile)

--- a/generate_workflows.py
+++ b/generate_workflows.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import pathlib
+import sys
+
+from jinja2 import Environment, FileSystemLoader
+
+if __name__ == '__main__':
+    project_dir = pathlib.Path(sys.path[0])
+    src_dir = project_dir / 'src/workflows/'
+    template_dir = src_dir / 'templates/'
+    workflows_dir = project_dir / '.github/workflows/'
+    env = Environment('<%', '%>', '<%=', '%>', '<%#', '%>',
+                      loader=FileSystemLoader(searchpath=[src_dir, template_dir]), autoescape=False, trim_blocks=True,
+                                              lstrip_blocks=True, keep_trailing_newline=True)
+
+    images = []
+    for dockerfile in project_dir.glob('Dockerfile.*'):
+        images.append(dockerfile.name.removeprefix('Dockerfile.'))
+
+    context = {
+        'images': images
+    }
+
+    for file in src_dir.glob('*.yml.j2'):
+        template = env.get_template(str(file.relative_to(src_dir)))
+        workflow = template.render(context)
+
+        print(workflow)
+
+        with open(workflows_dir / file.stem, 'w') as f:
+            f.write(workflow)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Jinja2==3.1.2
+MarkupSafe==2.1.1
+PyYAML==6.0

--- a/src/docker/templates/Dockerfile.base-focal.j2
+++ b/src/docker/templates/Dockerfile.base-focal.j2
@@ -1,0 +1,15 @@
+{%extends 'Dockerfile.base.j2' %}
+{% set codename='focal' %}
+
+{% import 'apt_macros.j2' as apt %}
+
+{% block repos %}
+    {{ apt.add_ubuntu_repo('bionic', ['main', 'universe']) }}
+    {{ apt.add_ubuntu_repo('xenial', ['main', 'universe']) }}
+    {{ apt.add_ubuntu_repo('xenial-updates', ['main', 'universe']) }}
+{% endblock %}
+
+{% block packages %}
+    {{ super() }}
+    libidn11
+{% endblock %}

--- a/src/docker/templates/Dockerfile.base-jammy.j2
+++ b/src/docker/templates/Dockerfile.base-jammy.j2
@@ -1,0 +1,8 @@
+{%extends 'Dockerfile.base.j2' %}
+{% set codename='jammy' %}
+
+{% import 'apt_macros.j2' as apt %}
+
+{% block repos %}
+    {{ apt.add_ubuntu_repo('focal', ['main', 'universe']) }}
+{% endblock %}

--- a/src/docker/templates/Dockerfile.base.j2
+++ b/src/docker/templates/Dockerfile.base.j2
@@ -1,0 +1,40 @@
+{% import 'apt_macros.j2' as apt %}
+
+FROM ubuntu:{{ codename }} AS json-ci-base-{{ codename }}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+RUN apt-get install --no-install-recommends -y software-properties-common
+
+# add repositories
+{% block repos %}
+    {{ apt.add_repo('ppa:ubuntu-toolchain-r/test') }}
+{% endblock %}
+
+# install packages
+RUN apt-get update
+{% filter docker.multiline %}
+RUN apt-get install -y --no-install-recommends
+    {% block packages %}
+        ca-certificates git gnupg gpg-agent lsb-release
+        make ninja-build unzip wget xz-utils
+    {% endblock %}
+{% endfilter %}
+
+# install latest CMake
+RUN CMAKE_VERSION=3.24.0
+RUN wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh
+RUN chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh
+RUN ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir
+RUN rm -v cmake-$CMAKE_VERSION-Linux-x86_64.sh
+
+# cleanup
+RUN rm -v /usr/local/bin/ccmake /usr/local/bin/cmake-gui /usr/local/bin/cpack
+RUN rm -rf /usr/local/doc/cmake /usr/local/man
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/* && \
+RUN find /usr/lib/x86_64-linux-gnu -type f -iname '*.a' -exec rm -v \{\} \+
+
+{% block cleanup %}
+{% endblock %}

--- a/src/docker/templates/Dockerfile.gcc-focal.j2
+++ b/src/docker/templates/Dockerfile.gcc-focal.j2
@@ -1,0 +1,10 @@
+{%include 'Dockerfile.base-focal.j2' %}
+
+FROM json-ci-base-focal AS json-ci-{{ image }}
+
+{% filter docker.multiline %}
+    RUN apt-get install -y --no-install-recommends
+        g++-{{ image_version }}
+        # TODO selectively enable multilib
+        g++-{{ image_version }}-multilib
+{% endfilter %}

--- a/src/docker/templates/Dockerfile.gcc-jammy.j2
+++ b/src/docker/templates/Dockerfile.gcc-jammy.j2
@@ -1,0 +1,21 @@
+{%include 'Dockerfile.base-jammy.j2' %}
+
+FROM json-ci-base-jammy AS json-ci-{{ image }}
+
+{% if image_version == 'latest' %}
+    # install latest GCC
+    RUN wget http://kayari.org/gcc-latest/gcc-latest.deb
+    RUN dpkg -i gcc-latest.deb
+    RUN rm -rf gcc-latest.deb
+    RUN ln -sv /opt/gcc-latest/bin/g++ /opt/gcc-latest/bin/g++-latest
+    RUN ln -sv /opt/gcc-latest/bin/gcc /opt/gcc-latest/bin/gcc-latest
+
+    ENV PATH={{ '${PATH}' }}:/opt/gcc-latest/bin
+{% else %}
+    {% filter docker.multiline %}
+        RUN apt-get install -y --no-install-recommends
+            g++-{{ image_version }}
+            # TODO selectively enable multilib
+            g++-{{ image_version }}-multilib
+    {% endfilter %}
+{% endif %}

--- a/src/docker/templates/apt_macros.j2
+++ b/src/docker/templates/apt_macros.j2
@@ -1,0 +1,11 @@
+{% macro add_repo(repo) -%}
+    RUN apt-add-repository -y "{{ repo }}"
+{%- endmacro %}
+
+{% macro add_ubuntu_repo(codename, components) -%}
+    {% if components is string %}
+        {{ add_repo('deb http://archive.ubuntu.com/ubuntu/ %s %s' % (codename, components)) }}
+    {% else %}
+        {{ add_repo('deb http://archive.ubuntu.com/ubuntu/ %s %s' % (codename, ' '.join(components))) }}
+    {% endif %}
+{%- endmacro -%}

--- a/src/workflows/build_and_publish.yml.j2
+++ b/src/workflows/build_and_publish.yml.j2
@@ -1,0 +1,13 @@
+name: Publish Docker images
+
+on:
+  push:
+  pull_request:
+
+jobs:
+<% for image in images %>
+<% filter indent(width=2, first=True) %>
+<% include 'build_and_publish_job.yml.j2' %>
+<% endfilter %>
+
+<% endfor %>

--- a/src/workflows/templates/build_and_publish_job.yml.j2
+++ b/src/workflows/templates/build_and_publish_job.yml.j2
@@ -1,0 +1,32 @@
+build_and_publish-<%= image %>:
+  name: Build and publish Docker image json-ci-<%= image %>
+  runs-on: ubuntu-latest
+  permissions:
+    packages: write
+    contents: read
+
+  steps:
+    - uses: actions/checkout@v2
+
+    - name: Log in to the GitHub Container registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata for Docker
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ghcr.io/${{ github.repository }}
+
+    - name: Build and push Docker image json-ci-<%= image %>
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: ${{ github.event_name != 'pull_request' }}
+        target: json-ci-<%= image %>
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This is very much work-in-progress and completely non-functional at this early stage of development.

Basic principles:
* `Dockerfile`s and the GitHub workflows are generated.
* `Dockerfile`s are generated from `config.yml` and the files in `src/docker`.
* GitHub workflows are generated from the file names `Dockerfile.*` and `src/workflows`.

How the templates are organized is still in flux. The use of Jinja filters like `docker.multiline` is just an experiment at this point.
The `publish_and_build.yml` workflow doesn't take advantage of the multistage Dockerfile, i.e., doesn't build and cache the base images separately.